### PR TITLE
Socket Middleware Closing update

### DIFF
--- a/src/middleware/socketMiddleware.js
+++ b/src/middleware/socketMiddleware.js
@@ -27,7 +27,7 @@ export const socketMiddleware = () => {
 				// TODO: socket.onclose = something to note this action in our store
 				break;
 			case 'SOCKET_CONN_UNMOUNT':
-				socket.close();
+				socket.readyState === 1 && socket.close();
 				break;
 			default:
 				next(action);


### PR DESCRIPTION
-Component unmounting now dispatches an action that checks readyState of socket before closing.
-This was implemented due to undefined errors occurring in socketMiddleware.