### PR TITLE
Socket unmount now checks for defined socket and ready status

### DIFF
--- a/src/__tests__/Login.test.js
+++ b/src/__tests__/Login.test.js
@@ -27,8 +27,6 @@ test('checks we are actually changing inputs', () => {
 	expect(screen.queryByText(testUsername)).toBe(testUsername);
 	expect(screen.queryByText(testUsername)).toBe(testUsername);
 });
-<<<<<<< HEAD
-=======
 //test commit message
->>>>>>> ab3da8fc8dcbc5088497b2604149f7de2c8871fa
 //add more to this test
+//adding more here today

--- a/src/middleware/socketMiddleware.js
+++ b/src/middleware/socketMiddleware.js
@@ -27,7 +27,9 @@ export const socketMiddleware = () => {
 				// TODO: socket.onclose = something to note this action in our store
 				break;
 			case 'SOCKET_CONN_UNMOUNT':
-				socket && socket.close();
+				if (socket && socket.readyStatus === 1) {
+					socket.close();
+				}
 				break;
 			default:
 				next(action);


### PR DESCRIPTION
-Use effect is calling unmount on board component mount. This can prematurely cancel a socket connection before it is successful. On board mount, board id is null, changes to uuid, which triggers useEffect to run again and create socket connection with appropriate board id. This fix removes console warnings of premature exits from initial ws request.